### PR TITLE
Use extras in tox instead of self-referencing the package in deps

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,8 +9,8 @@ envlist =
     lint
 
 [testenv]
-deps =
-    .[test]
+extras =
+    test
 commands =
     pytest {posargs}
 


### PR DESCRIPTION
This is the more idiomatic way.

Also, it allows Fedora packaging to actually install the deps.